### PR TITLE
Unify Request to become a DNA

### DIFF
--- a/DNA-Registry.csv
+++ b/DNA-Registry.csv
@@ -22,3 +22,4 @@
 "Mark Atwood","me@mark.atwood.name","me@mark.atwood.name","http://about.me/markatwood","DWF-YEAR-93000","DWF-YEAR-93999"
 "NTPsec Security Team","security@ntpsec.org","security@ntpsec.org","http://ntpsec.org/","DWF-YEAR-94000","DWF-YEAR-94999"
 "OpenSwitch Security Team","security@openswitch.net","security@openswitch.net","http://openswitch.net/","DWF-YEAR-95000","DWF-YEAR-95999"
+"Unify Product Security Team (OpenScape Baseline Security Office)","obso@unify.com","obso@unify.com","https://www.unify.com/security/advisories","DWF-YEAR-96000","DWF-YEAR-96999"


### PR DESCRIPTION
As a software vendor we attempt to get a CVE ID for all issues we're publishing in the context of our VIP (Vulnerability Intelligence Process Policy), see https://www.unify.com/security/advisories. This includes both issues in open source modules embedded in our products as well as the own SW we write. We successfully requested CVE IDs in the past directly from Mitre, regardless if the vulnerability was identified by us, or by an external researcher.
For us, CVE assignment by Mitre is currently on hold due to their CVE published priorities. Provided that DWE and CVE will merge soon, we fully support this approach and like to start quickly with the assignment of 6 DWE IDs for upcoming vulnerbility disclosures in our products...
We also believe that this approach (once agreed-upon with Mitre) will support Mitre themselves in keeping the CVE standard at the level it deserves.
